### PR TITLE
Refactor/components on their own folder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,12 @@
 import './App.css';
-import { useContext } from 'react';
-import FormContext from './context/formContext';
-import WithBoard from './HOC/WithBoard';
-import SortedMatches from './components/SortedMatches';
-import AddMatchForm from './components/AddMatchForm';
+import LiveScoreBoard from './components/LiveScoreBoard';
 
-function App() {
-    const { error, liveScores } = useContext(FormContext);
+const App = () => (
+    <div className='App'>
+        <h1>Football Live Score Board</h1>
+        <hr />
+        <LiveScoreBoard />
+    </div>
+);
 
-    return (
-        <div className='App'>
-            <h1>Football Live Score Board</h1>
-            <hr />
-            <AddMatchForm />
-            {error && (
-                <p role='alert' id='error-message' style={{ color: 'red' }}>
-                    {error}
-                </p>
-            )}
-            <SortedMatches data={liveScores} />
-        </div>
-    );
-}
-export default WithBoard(App);
+export default App;

--- a/src/components/AddMatchForm/__tests__/index.test.tsx
+++ b/src/components/AddMatchForm/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import WithBoard from '../../HOC/WithBoard';
-import AddMatchForm from '../AddMatchForm';
+import WithBoard from '../../../HOC/WithBoard';
+import AddMatchForm from '..';
 
 describe('AddMatchForm Cases', () => {
     test('Render just fine', () => {
@@ -15,13 +15,13 @@ describe('AddMatchForm Cases', () => {
     test("Fails: Can't access Context", () => {
         render(<AddMatchForm />);
 
-        const test = screen.getByText(/submit/i);
-        expect(test).toBeInTheDocument();
+        const submitButton = screen.getByText(/submit/i);
+        expect(submitButton).toBeInTheDocument();
 
         // mock console
         const consoleError = jest.spyOn(global.console, 'error').mockImplementation(() => {});
 
-        fireEvent.click(test);
+        fireEvent.click(submitButton);
         expect(consoleError).toHaveBeenCalledTimes(1);
 
         // restore console

--- a/src/components/AddMatchForm/index.tsx
+++ b/src/components/AddMatchForm/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import FormContext from '../context/formContext';
+import FormContext from '../../context/formContext';
 
 /**
  * Form for adding (starting) new matches

--- a/src/components/LiveScoreBoard/__tests__/index.test.tsx
+++ b/src/components/LiveScoreBoard/__tests__/index.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import LiveScoreBoard from '..';
+
+describe('LiveScoreBoard Cases', () => {
+    test('Renders just fine', () => {
+        expect(() => <LiveScoreBoard />).not.toThrowError();
+    });
+
+    test('Catch and display errors', async () => {
+        render(<LiveScoreBoard />);
+
+        const homeInput = screen.getByLabelText(/home team/i);
+        await fireEvent.change(homeInput, { target: { value: 123 } });
+        await fireEvent.click(screen.getByText(/submit/i));
+
+        expect(await screen.findByRole(/alert/)).toBeInTheDocument();
+    });
+});

--- a/src/components/LiveScoreBoard/index.tsx
+++ b/src/components/LiveScoreBoard/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 
 import SortedMatches from '../SortedMatches';
 
-import UnsortedMatches from '../UnsortedMatches';
+import ActiveMatchesList from '../UnsortedMatches';
 import AddMatchForm from '../AddMatchForm';
 import FormContext from '../../context/formContext';
 import WithBoard from '../../HOC/WithBoard';
@@ -33,7 +33,7 @@ const LiveScoreBoard = () => {
 
                 <div style={{ display: 'flex', justifyContent: 'space-evenly', width: '100%' }}>
                     <div style={{ margin: '0 2rem' }}>
-                        <UnsortedMatches />
+                        <ActiveMatchesList />
                     </div>
                     <div style={{ margin: '0 2rem' }}>
                         <SortedMatches data={liveScores} />

--- a/src/components/LiveScoreBoard/index.tsx
+++ b/src/components/LiveScoreBoard/index.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from 'react';
+
+import SortedMatches from '../SortedMatches';
+
+import UnsortedMatches from '../UnsortedMatches';
+import AddMatchForm from '../AddMatchForm';
+import FormContext from '../../context/formContext';
+import WithBoard from '../../HOC/WithBoard';
+
+/**
+ * Main scores boarc where it connects transparently to the
+ * FormContext provider and Board() from `football-score-board`
+ * It makes use of *{liveScores, error}* from *FormContext*
+ */
+const LiveScoreBoard = () => {
+    const { liveScores, error } = useContext(FormContext);
+
+    return (
+        <React.Fragment>
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                }}>
+                <AddMatchForm />
+
+                {error && (
+                    <p role='alert' id='error-message' style={{ color: 'red' }}>
+                        {error}
+                    </p>
+                )}
+
+                <div style={{ display: 'flex', justifyContent: 'space-evenly', width: '100%' }}>
+                    <div style={{ margin: '0 2rem' }}>
+                        <UnsortedMatches />
+                    </div>
+                    <div style={{ margin: '0 2rem' }}>
+                        <SortedMatches data={liveScores} />
+                    </div>
+                </div>
+            </div>
+        </React.Fragment>
+    );
+};
+
+export default WithBoard(LiveScoreBoard);

--- a/src/components/SortedMatches/__tests__/index.test.tsx
+++ b/src/components/SortedMatches/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import SortedMatches from '../SortedMatches';
+import SortedMatches from '..';
 
 describe('SortedMatches Cases', () => {
     test('Render just fine', () => {

--- a/src/components/SortedMatches/index.tsx
+++ b/src/components/SortedMatches/index.tsx
@@ -1,3 +1,7 @@
+/**
+ * List of matches (games) sorted by total scores
+ * @param {string[]} data Array of games and scores already sorted
+ */
 const SortedMatches = ({ data }: { data: string[] }) => (
     <>
         <h2>Live Sorted Matches</h2>

--- a/src/components/UnsortedMatches/__tests__/index.test.tsx
+++ b/src/components/UnsortedMatches/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import FormContext, { defaultContextValues } from '../../context/formContext';
-import { PlayingMatchesTypes } from '../../context/types';
-import UnsortedMatches from '../UnsortedMatches';
+import FormContext, { defaultContextValues } from '../../../context/formContext';
+import { PlayingMatchesTypes } from '../../../context/types';
+import UnsortedMatches from '..';
 
 describe('UnsortedMatches Cases', () => {
     test('Render just fine', () => {

--- a/src/components/UnsortedMatches/__tests__/index.test.tsx
+++ b/src/components/UnsortedMatches/__tests__/index.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import FormContext, { defaultContextValues } from '../../../context/formContext';
 import { PlayingMatchesTypes } from '../../../context/types';
-import UnsortedMatches from '..';
+import ActiveMatchesList from '..';
 
 describe('UnsortedMatches Cases', () => {
     test('Render just fine', () => {
-        render(<UnsortedMatches />);
+        render(<ActiveMatchesList />);
 
         expect(screen.getByText(/live matches/i)).toBeInTheDocument();
     });
@@ -20,7 +20,7 @@ describe('UnsortedMatches Cases', () => {
 
         render(
             <FormContext.Provider value={mockValue}>
-                <UnsortedMatches />
+                <ActiveMatchesList />
             </FormContext.Provider>,
         );
 
@@ -43,7 +43,7 @@ describe('UnsortedMatches Cases', () => {
 
         render(
             <FormContext.Provider value={mockValue}>
-                <UnsortedMatches />
+                <ActiveMatchesList />
             </FormContext.Provider>,
         );
 
@@ -71,7 +71,7 @@ describe('UnsortedMatches Cases', () => {
 
         const TestingComponent = () => (
             <FormContext.Provider value={mockValue}>
-                <UnsortedMatches />
+                <ActiveMatchesList />
             </FormContext.Provider>
         );
 
@@ -105,7 +105,7 @@ describe('UnsortedMatches Cases', () => {
 
         render(
             <FormContext.Provider value={mockValue}>
-                <UnsortedMatches />
+                <ActiveMatchesList />
             </FormContext.Provider>,
         );
 

--- a/src/components/UnsortedMatches/index.tsx
+++ b/src/components/UnsortedMatches/index.tsx
@@ -1,7 +1,11 @@
 import { useContext } from 'react';
-import FormContext from '../context/formContext';
-import Button from './styledComponents/Button';
+import FormContext from '../../context/formContext';
+import Button from '../styledComponents/Button';
 
+/**
+ * List of matches (games) displayed by their added (started) time
+ * It makes use of *{playingMatches, handleDelete, handleScore}* from *FormContext*
+ */
 const UnsortedMatches = () => {
     const { playingMatches, handleDelete, handleScore } = useContext(FormContext);
 

--- a/src/components/UnsortedMatches/index.tsx
+++ b/src/components/UnsortedMatches/index.tsx
@@ -6,7 +6,7 @@ import Button from '../styledComponents/Button';
  * List of matches (games) displayed by their added (started) time
  * It makes use of *{playingMatches, handleDelete, handleScore}* from *FormContext*
  */
-const UnsortedMatches = () => {
+const ActiveMatchesList = () => {
     const { playingMatches, handleDelete, handleScore } = useContext(FormContext);
 
     return (
@@ -28,4 +28,4 @@ const UnsortedMatches = () => {
     );
 };
 
-export default UnsortedMatches;
+export default ActiveMatchesList;


### PR DESCRIPTION
### What changed:
All components have been converted from being simple files (ie: _AddMatchForm.tsx_) in the components folder to be contained in their own folders with their own tests.

### What resolves:
Better structuring and clarity. Better for maintenance.